### PR TITLE
Changed the Facebook link to go to the Better Because Project's Facebook page

### DIFF
--- a/app/views/partials/footer.pug
+++ b/app/views/partials/footer.pug
@@ -41,7 +41,7 @@ section#variable
 section#socialMedia.sectionFooter
 	ul#socialMediaSection
 			li.mediaOutlet
-				a(href='https://www.facebook.com/fleurtechnologies').fab.fa-facebook
+				a(href='https://www.facebook.com/thebetterbecauseproject').fab.fa-facebook
 .bottomRow
 	.copyrightInformation
 		p.copyright 


### PR DESCRIPTION
The Facebook icon in the footer currently takes the user to the Facebook page of Fleur Technologies.

At Rebecca's request, changed the Facebook icon to go to the Better Because Project's Facebook page.

This PR is a fix for issue https://github.com/TheGreatAxios/thebetterbecauseproject/issues/1