### PR TITLE
Remove the Pages column of links in the footer

### DIFF
--- a/app/views/partials/footer.pug
+++ b/app/views/partials/footer.pug
@@ -1,10 +1,4 @@
 footer.footer
-	section#navigation
-		h5 Pages
-		.links
-			a.link(href='/') Home
-			a.link(href='/about') About
-			a.link(href='/stories') Stories
 	section#legalContact
 		h5 Legal
 		.links


### PR DESCRIPTION
The footer has a column of navigation links with the heading of Pages. These links are redundant, as these same links are displayed at the top of each page. This PR removes the redundant links in the footer.

This PR is a fix for issue https://github.com/TheGreatAxios/thebetterbecauseproject/issues/6