### PR TITLE
Missed a style change for the copy added below the title heading

### DIFF
--- a/public/sass/index.css
+++ b/public/sass/index.css
@@ -606,17 +606,6 @@ header {
       font-family: Helvetica, sans-serif;
       text-decoration: none;
       margin: 5% 0 0 0; }
-    #sectionMain .centerPara h4 {
-      -webkit-align-self: center;
-      -ms-flex-item-align: center;
-      -ms-grid-row-align: center;
-      align-self: center;
-      text-align: center;
-      color: #FFFFFF;
-      padding: 0 10% 4% 10%;
-      font-family: Helvetica, sans-serif;
-      text-decoration: none;
-      margin: 0% 10% 0% 10%; }
       @media only screen and (min-device-width: 1px) and (max-device-width: 768px) {
         #sectionMain .centerPara h1 {
           font-size: 30px; } }
@@ -626,6 +615,15 @@ header {
       @media only screen and (min-device-width: 1024px) {
         #sectionMain .centerPara h1 {
           font-size: 45px; } }
+    #sectionMain .centerPara h4 {
+      -webkit-align-self: center;
+      -ms-flex-item-align: center;
+      -ms-grid-row-align: center;
+      align-self: center;
+      text-align: center;
+      color: #FFFFFF;
+      padding: 0 10% 4% 10%;
+      margin: 0 10% 4% 10%; }
 
 .formTitleSection {
   padding: 5%;

--- a/public/sass/index.scss
+++ b/public/sass/index.scss
@@ -66,7 +66,17 @@
 			padding: 0 0 5% 0;
 			@include headerfont;
 			margin: 5% 0 0 0;
-		}	
+		}
+		h4 {
+			-webkit-align-self: center;
+			    -ms-flex-item-align: center;
+			            -ms-grid-row-align: center;
+			        align-self: center;
+			text-align: center;
+			color: $white;
+			padding: 0 10% 4% 10%;
+			margin: 0 10% 4% 10%;
+		}
 	}
 }
 .formTitleSection {


### PR DESCRIPTION
A previous PR was missing a Sass style change for the new headings on the front page.

This PR is a further fix for issue https://github.com/TheGreatAxios/thebetterbecauseproject/issues/9