### PR TITLE
Change the Facebook link to open the BBP FB page in a new tab

### DIFF
--- a/app/views/partials/footer.pug
+++ b/app/views/partials/footer.pug
@@ -36,7 +36,7 @@ section#variable
 section#socialMedia.sectionFooter
 	ul#socialMediaSection
 			li.mediaOutlet
-				a(href='https://www.facebook.com/thebetterbecauseproject').fab.fa-facebook
+				a(href='https://www.facebook.com/thebetterbecauseproject', target='_blank').fab.fa-facebook
 .bottomRow
 	.copyrightInformation
 		p.copyright 


### PR DESCRIPTION
The Facebook link in the footer took the current browser window to the FB page for BBP. This PR changes the behavior to open the FB page on a new tab instead. 

This PR is a fix for issue https://github.com/TheGreatAxios/thebetterbecauseproject/issues/16