### PR TITLE
Add dummy keys for Medium API to .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,3 +6,5 @@ SECRET=better
 MONGO_URI_PRODUCTION=mongodb+srv://admin:admin@stories-mduag.mongodb.net/test?retryWrites=true
 MONGO_URI_DEV=mongodb+srv://admin:admin@stories-mduag.mongodb.net/test?retryWrites=true
 NODE_ENV=development
+MEDIUM_CLIENT_ID=12345
+MEDIUM_CLIENT_SECRET=1234567890


### PR DESCRIPTION
This change is so other developers don't get crashes when hitting the OAuth authentication request page in their testing.