### PR TITLE
Removed the MHASF content from the About page

### DIFF
--- a/app/views/about.pug
+++ b/app/views/about.pug
@@ -65,17 +65,6 @@ block content
 								br
 								br
 								br
-					section.splitScreen#mhasfSection
-						.splitImageSection
-							a(href='https://www.mentalhealthsf.org')
-								img(src='/images/mhasfLogoWhiteBG.jpg', alt='Logo for the Mental Health Association of San Francisco')
-						.splitTextSection
-							a(href='https://www.mentalhealthsf.org')
-								h2.splitTitle Mental Health Association of San Francisco
-							h3.splitTitle Partnering Organization of The Better Because Project
-							p.splitText
-								br
-								| The Mental Health Association of San Francisco (MHASF) is a proud partner of The Better Because Project. MHASF is a 90% peer-run organization that has supported fellow peers with mental health challenges for over 70 years.
 	include partials/footer
 	link(rel="stylesheet", href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css", integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T", crossorigin="anonymous")
 	link(rel='stylesheet', href='https://use.fontawesome.com/releases/v5.1.0/css/all.css', integrity='sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt', crossorigin='anonymous')


### PR DESCRIPTION
Removed the MHASF content from the About page. We are no longer seeking to be associated with them.